### PR TITLE
refactor: Moved the array to the tasks and only left the source file …

### DIFF
--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -79,10 +79,8 @@ filebeat_config_template:
   - src: templates/filebeat/filebeat.yml.j2
     dest: "{{ observability_root_path }}/filebeat/filebeat.yml"
 
-# Use the below variables to provide your own Prometheus config files:
-prometheus_config_template:
-  - src: templates/prometheus/prometheus.yml.j2
-    dest: "{{ observability_root_path }}/prometheus/prometheus.yml"
+# Use the below variables to provide your own Prometheus config file:
+prometheus_config_template: templates/prometheus/prometheus.yml.j2
 
 # If you customized Prometheus config file and don't use Service Dicovery
 # set this variable to an empty list in your Playbook
@@ -91,6 +89,7 @@ prometheus_service_discovery_target_templates:
     dest: "{{ observability_root_path }}/prometheus/{{ prometheus_service_discovery_all_targets_file }}"
   - src: templates/prometheus/{{ prometheus_service_discovery_client_targets_file }}.j2
     dest: "{{ observability_root_path }}/prometheus/{{ prometheus_service_discovery_client_targets_file }}"
+
 
 prometheus_service_discovery_all_targets_file: sd_all_targets.yml
 prometheus_service_discovery_client_targets_file: sd_client_targets.yml

--- a/tasks/obs_center.yml
+++ b/tasks/obs_center.yml
@@ -20,7 +20,10 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: '0755'
-  loop: "{{ prometheus_config_template }}"
+  loop:
+    - src: "{{ prometheus_config_template }}"
+      dest: "{{ observability_root_path }}/prometheus/prometheus.yml"
+
   notify:
     - Restart prometheus container
 


### PR DESCRIPTION
…in the vars

There was no reason for role users to edit the destination file name, which would have broken Prometheus